### PR TITLE
Add docker-compose config with custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,65 @@
 # WebHookGen
 
-WebHookGen is a minimal Flask application used to receive webhook requests and display them in a web UI.
+WebHookGen is a minimal Flask application used to receive webhook requests and display them in a simple web UI.
 
 ## Getting Started
 
-1. Install dependencies and run the app locally:
+### Local Development
 
-   ```bash
-   python -m venv venv
-   source venv/bin/activate
-   pip install -r requirements.txt
-   python app/main.py
-   ```
-
-   ### Setup
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python app/main.py
 ```
+
+### Repository Setup
+
+```bash
 git clone https://github.com/sherafyk/WebHookGen.git
-```
-```
 cd WebHookGen
 ```
-   #### Updating
 
-Pull the latest changes and rebuild:
+#### Updating
+
+Pull the latest changes and rebuild with Docker Compose:
+
 ```bash
-docker-compose down
+docker compose down
 git pull
-docker-compose up -d --build
+docker compose up -d --build
 ```
+
 ##### Additional diagnostic checks
 
-```
+```bash
 docker ps
-```
-```
-docker logs sfk3-app-1 --tail=100
+docker logs <container_name> --tail=100
 ```
 
-2. Build and run with Docker:
+### Build and Run with Docker
 
-   ```bash
-   docker build -t webhook-gen .
-   docker run -d \
-     --name webhook-gen \
-     -e WEBHOOK_PASS=AppPass1 \
-     -p 5000:5000 \
-     -v "$PWD/app/data.json":/app/data.json \
-     webhook-gen
-   ```
+```bash
+docker build -t webhook-gen .
+docker run -d \
+  --name webhook-gen \
+  -e WEBHOOK_PASS=AppPass1 \
+  -p 5000:5000 \
+  -v "$PWD/app/data.json":/app/data.json \
+  webhook-gen
+```
 
-The application listens on port `5000`. Use `http://localhost:5000/` in your browser and authenticate with `admin` and the password specified by `WEBHOOK_PASS` (defaults to `AppPass1`).
+### Run with Docker Compose
+
+The repository includes a `docker-compose.yml` file that exposes the app on port `50011`.
+
+```bash
+docker compose up -d --build
+```
+
+Visit `http://localhost:50011/`.
+
+The application listens on the port defined by the `PORT` environment variable (default `5000`). When using Docker Compose it is configured to run on `50011`. Authenticate with `admin` and the password set in `WEBHOOK_PASS` (defaults to `AppPass1`).
 
 ## Webhook Usage
 
@@ -63,10 +73,11 @@ app/
 ├── data.json      - Stored submissions
 └── templates/
     └── index.html - Simple UI to list submissions
-Dockerfile          - Container build instructions
-requirements.txt    - Python dependencies
+Dockerfile         - Container build instructions
+docker-compose.yml - Example compose setup
+requirements.txt   - Python dependencies
 ```
 
 ## Notes
 
-`WEBHOOK_PASS` can be set as an environment variable to change the admin password. Mounting `app/data.json` when using Docker ensures submissions persist between runs.
+`WEBHOOK_PASS` can be set as an environment variable to change the admin password. Mount `app/data.json` when using Docker to ensure submissions persist between runs.

--- a/app/main.py
+++ b/app/main.py
@@ -48,4 +48,5 @@ def webhook():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    port = int(os.getenv('PORT', '5000'))
+    app.run(host='0.0.0.0', port=port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "50011:50011"
+    environment:
+      - WEBHOOK_PASS=AppPass1
+      - PORT=50011
+    volumes:
+      - ./app/data.json:/app/data.json


### PR DESCRIPTION
## Summary
- allow Flask port to be configured via the `PORT` env var
- provide `docker-compose.yml` running the app on port **50011**
- clean up README with compose usage instructions

## Testing
- `python -m py_compile app/main.py`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853b3a1f17c832d85521b7b597aab81